### PR TITLE
タグによる分類を実装

### DIFF
--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -5,6 +5,7 @@ const CategoryList = styled.ul`
   padding: 4px 0 0 0;
   list-style: none;
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
 `;
 

--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -1,0 +1,85 @@
+import styled from 'styled-components';
+
+const CategoryList = styled.ul`
+  margin: 0;
+  padding: 4px 0 0 0;
+  list-style: none;
+  display: flex;
+  gap: 10px;
+`;
+
+const CategoryItemCheck = styled.div<{ selected: boolean; keyColor: string }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ selected, keyColor }) => (selected ? '#fff' : keyColor)};
+  opacity: ${({ selected }) => (selected ? 1 : 0.2)};
+  transition: opacity 0.2s;
+`;
+
+const Button = styled.button<{ selected: boolean; keyColor: string }>`
+  height: 14px;
+  line-height: 14px;
+  color: ${({ selected, keyColor }) => (selected ? '#fff' : keyColor)};
+  font-size: 14px;
+  padding: 6px 8px 8px 10px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  background: ${({ selected, keyColor }) => (selected ? keyColor : '#fff')};
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-sizing: content-box;
+  transition: color 0.2s, background 0.2s;
+
+  &:hover ${CategoryItemCheck} {
+    opacity: 1;
+  }
+`;
+
+interface Option {
+  key: string;
+  label: string;
+  keyColor: string;
+}
+
+interface CheckboxProps {
+  options: Option[];
+  multiple: boolean;
+  selectedOptions: string[];
+  setSelectedOptions: (value: string[]) => void;
+}
+
+const Checkbox = ({ options, selectedOptions, setSelectedOptions }: CheckboxProps) => {
+  const onClickCategoryItem = (key: string) => {
+    setSelectedOptions(
+      selectedOptions.includes(key)
+        ? selectedOptions.filter((option) => option !== key)
+        : [...selectedOptions, key]
+    );
+  };
+
+  return (
+    <CategoryList>
+      {options.map((option) => {
+        const selected = selectedOptions.includes(option.key);
+        return (
+          <li key={option.key}>
+            <Button
+              selected={selected}
+              keyColor={option.keyColor}
+              onClick={() => onClickCategoryItem(option.key)}
+            >
+              <CategoryItemCheck selected={selected} keyColor={option.keyColor} />
+              {option.label}
+            </Button>
+          </li>
+        );
+      })}
+    </CategoryList>
+  );
+};
+export default Checkbox;

--- a/src/const/articles.ts
+++ b/src/const/articles.ts
@@ -3,7 +3,7 @@ export interface ArticleLink {
   title: string;
   date: string;
   description?: string;
-  tags?: string[];
+  tags: string[];
 }
 
 export const articleHatenaLinks: ArticleLink[] = [
@@ -11,71 +11,91 @@ export const articleHatenaLinks: ArticleLink[] = [
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20180321/1521620634',
     title: '3 日間。Python でつくる、Twitter カウントダウン Bot',
     date: '2018/03/21',
+    tags: ['tech'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20190404/1554383981',
     title: '【WebAR】世界最速、AR で「令和」発表を再現（デモあり）',
     date: '2019/04/04',
+    tags: ['tech'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20190511/1557550216',
     title: 'Twitter を完璧に制限する「ダツイハイ」を開発しました',
     date: '2019/05/11',
+    tags: ['tech'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20200309/1583739357',
     title: '英検パス単の音声データから単語と対訳を抜き出していい感じに加工するツールを作りました',
     date: '2020/03/09',
+    tags: ['tech'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20200319/1584600532',
     title: 'Chrome 拡張機能で Twitter に桜を降らせる',
     date: '2020/03/19',
+    tags: ['tech'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20210322/1616418041',
     title: '容量無制限の YouTube に写真を保存して Google フォト代わりに使うソフトを作ったよ！！',
     date: '2021/03/22',
+    tags: ['tech'],
+  },
+  {
+    href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20211012/1633979685',
+    title: '筑波大学 国際科学オリンピック特別入試体験記',
+    date: '2021/10/12',
+    tags: ['tech'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20211231/1640943650',
     title: '2021 年を振り返って',
     date: '2021/12/31',
+    tags: ['random'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20220525/1653446933',
     title: '日米友好祭 2022 に行ってきた',
     date: '2022/05/25',
+    tags: ['random'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20220919/1663521375',
     title: 'はてなインターン 2022 に参加しました',
     date: '2022/09/19',
+    tags: ['random'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20221218/1671298432',
     title: '某某宿舎での一年',
     date: '2022/12/18',
+    tags: ['random'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20221231/1672497754',
     title: '2022 年を振り返って',
     date: '2022/12/31',
+    tags: ['random'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20230319/1679216111',
     title: 'なぜ我々は筑波大を便利にすることができなかったのか？',
     date: '2023/03/19',
+    tags: ['random'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20230322/1679413012',
     title: 'やはり俺の青春ラブコメはまちがっている。聖地巡礼記',
     date: '2023/03/22',
+    tags: ['hongoshi', 'random'],
   },
   {
     href: 'https://soudakyoto-ikou.hatenadiary.jp/entry/20230411/1681167907',
     title: '3 度目の春が来る',
     date: '2023/04/11',
+    tags: ['random'],
   },
 ];
 
@@ -84,86 +104,97 @@ export const articleZennLinks: ArticleLink[] = [
     href: 'https://zenn.dev/inaniwaudon/articles/039e82d61254ed',
     title: 'ヒラギノ角ゴシックの CMap を読む',
     date: '2022/01/22',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/832ecf5180d527',
     title: '忙しい人のための CFF テーブル入門: PDF にOpenTypeフォントのサブセットを埋め込むには',
     date: '2022/01/26',
-    tags: ['hongoshi'],
+    tags: ['hongoshi', 'tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/9cc5fcd5a08530',
     title: 'Next.js でクライアントでのみコードを実行したい',
     date: '2022/05/16',
+    tags: ['tech'],
   },
   {
     href: 'https://qiita.com/inaniwaudon/items/46ac7ece438febde1538',
     title: 'styled-componentsで隣接セレクタを使用する',
     date: '2022/07/10',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/a80f7dc66ffe92',
     title: 'Web だって組版の夢を見る――新聞のように自在にテキストを流し込むには',
     date: '2022/07/26',
-    tags: ['hongoshi'],
+    tags: ['hongoshi', 'tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/e7c11633685cf5',
     title: 'Illustrator 上でルビを振るスクリプト illustrator-ruby を公開しました',
     date: '2022/08/17',
-    tags: ['hongoshi'],
+    tags: ['hongoshi', 'tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/62dfe3923f8521',
     title: 'styled-components で CSS Animation を再度実行する',
     date: '2022/10/03',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/a18ee47ce1488a',
     title: 'Type 2 Charstring を読み解いて OpenType フォントを描画してみる',
     date: '2022/11/16',
-    tags: ['hongoshi'],
+    tags: ['hongoshi', 'tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/e4d6d326c4c18b',
     title: '筑波大学学園祭 Web サイト構築の舞台裏',
     date: '2022/12/15',
-    tags: ['hongoshi'],
+    tags: ['hongoshi', 'tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/12fc531cb89813',
     title: 'プログラミング初学者の大学生が動かないコードを動かすには？',
     date: '2022/12/25',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/e01d84841aafe7',
     title: '年賀状の宛名をサクッと作るためのツールを公開しました',
     date: '2022/12/28',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/b361c4f996c980',
     title: 'Twitter 上のイラストを快適に閲覧するための Web アプリを公開しました',
     date: '2023/01/22',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/df0b0959d61b23',
     title: 'hyperref パッケージは PDF の注釈機能を用いて実現されている',
     date: '2023/02/16',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/8ce67c38ed3624',
     title: '郷に入れば郷に従って npm/yarn を切り替えるスクリプト',
     date: '2023/02/21',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/a796af99ab834f',
     title: 'input 要素に flex-shrink が効かないときの対処法',
     date: '2023/02/27',
+    tags: ['tech'],
   },
   {
     href: 'https://zenn.dev/inaniwaudon/articles/0ccec9aab37032',
     title: 'Intl.segmenter + React で改行位置の制御',
     date: '2023/04/30',
+    tags: ['tech'],
   },
 ];
 
@@ -172,13 +203,13 @@ export const articleNoteLinks: ArticleLink[] = [
     href: 'https://note.com/soudakyoto_ikou/n/n6967b2471eca',
     title: 'サイエンスフロンティア高校のポスターに学ぶ！グラフィックデザイン基本の「き」',
     date: '2019/06/02',
-    tags: ['hongoshi'],
+    tags: ['hongoshi', 'design'],
   },
   {
     href: 'https://note.com/soudakyoto_ikou/n/nd63330df85d8',
     title: 'まんがタイムきららの「写植」を読む――吹き出しにみる漫画書体の使い分け',
     date: '2023/01/29',
-    tags: ['hongoshi'],
+    tags: ['hongoshi', 'design'],
   },
 ];
 
@@ -187,6 +218,7 @@ export const articleSiteLinks: ArticleLink[] = [
     href: '/articles/max',
     title: 'マックスコーヒーのパッケージ観察',
     date: '2023/05/14',
+    tags: ['hongoshi', 'design'],
   },
 ];
 
@@ -196,23 +228,27 @@ export const articleWordLinks: ArticleLink[] = [
     title: '書いてみよう！組版処理系',
     date: '2021/09/12',
     description: 'WORD 50号',
+    tags: ['tech'],
   },
   {
     href: '/docs/word-takutsu.pdf',
     title: '宅通......本当にするのですか？',
     date: '2022/02/26',
     description: 'WORD 引っ越し準備号 2022',
+    tags: ['random'],
   },
   {
     href: '/docs/word-adobe.pdf',
     title: 'あの日見た Adobe CC の名前を僕達はまだ知らない。',
     date: '2022/03',
     description: 'WORD 入学祝い号 2023',
+    tags: ['random'],
   },
   {
     href: 'https://www.word-ac.net/post/2022/0811-word52/',
     title: '令和4年度版 おすすめエナドリ 10 選',
     date: '2022/08/11',
     description: 'WORD 52号',
+    tags: ['random'],
   },
 ];

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import styled from 'styled-components';
+import Checkbox from '@/components/common/Checkbox';
 import CustomList from '@/components/common/CustomList';
 import Page from '@/components/common/Page';
 import PageAnchor from '@/components/common/PageAnchor';
@@ -12,10 +13,14 @@ import {
 } from '@/const/articles';
 
 const H1 = styled.h1`
-  margin: 0 0 10px 0;
+  margin: 0 0 8px 0;
 `;
 
-const Header = styled.header`
+const TopHeader = styled.header`
+  margin-bottom: 16px;
+`;
+
+const ArticleHeader = styled.header`
   font-size: 14px;
 `;
 
@@ -35,6 +40,14 @@ const Description = styled.span`
 `;
 
 const Index = () => {
+  const tags = [
+    { key: 'hongoshi', label: 'hongoshi', keyColor: '#ff32ab' },
+    { key: 'tech', label: 'tech', keyColor: '#cc22db' },
+    { key: 'design', label: 'design', keyColor: '#2656f3' },
+    { key: 'random', label: 'random', keyColor: '#009ae1' },
+  ];
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
   const links = useMemo(() => {
     const hatena = articleHatenaLinks.map((link) => ({ ...link, description: 'はてなブログ' }));
     const note = articleNoteLinks.map((link) => ({ ...link, description: 'note' }));
@@ -48,18 +61,31 @@ const Index = () => {
     );
   }, [articleHatenaLinks, articleNoteLinks, articleZennLinks, articleWordLinks]);
 
+  const filteredLinks =
+    selectedTags.length > 0
+      ? links.filter((link) => link.tags && selectedTags.some((tag) => link.tags!.includes(tag)))
+      : links;
+
   const title = '書いたもの・こと';
 
   return (
     <Page title={title}>
       <main>
-        <H1>{title}</H1>
+        <TopHeader>
+          <H1>{title}</H1>
+          <Checkbox
+            options={tags}
+            multiple={true}
+            selectedOptions={selectedTags}
+            setSelectedOptions={setSelectedTags}
+          />
+        </TopHeader>
         <CustomList>
-          {links.map((link) => (
+          {filteredLinks.map((link) => (
             <li key={link.href}>
-              <Header>
+              <ArticleHeader>
                 <Time>{link.date}</Time> - <Description>{link.description}</Description>
-              </Header>
+              </ArticleHeader>
               <ListH3>
                 <PageAnchor href={link.href}>{link.title}</PageAnchor>
               </ListH3>


### PR DESCRIPTION
fix: #16
- 記事ページにタグによる分類を実装
- [筑波大学 国際科学オリンピック特別入試体験記](https://soudakyoto-ikou.hatenadiary.jp/entry/20211012/1633979685) の記事を追加