### PR TITLE
Safari で画像のアップロードに失敗する問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@linaria/core": "^5.0.2",
     "@linaria/react": "^5.0.3",
     "argparse": "^2.0.1",
+    "browser-image-compression": "^2.0.2",
     "feed": "^4.2.2",
     "natsort": "^2.0.3",
     "next": "~13.5.6",

--- a/src/app/locations/[id]/checkin/Content.tsx
+++ b/src/app/locations/[id]/checkin/Content.tsx
@@ -134,7 +134,7 @@ const Content = ({ id, initialCheckin }: ContentProps) => {
       return;
     }
 
-    // base64 を imageId に差し替え
+    // base64 をファイル名に差し替え
     const newPhotos = [...photos];
     let base64Index = 0;
     for (const photo of newPhotos) {

--- a/src/app/locations/_lib/api.ts
+++ b/src/app/locations/_lib/api.ts
@@ -126,8 +126,8 @@ export const postImages = async (id: string, images: string[]) => {
     if (!response.ok) {
       return fail(await response.text());
     }
-    const imageIds = (await response.json()) as string[];
-    return succeed(imageIds);
+    const filenames = (await response.json()) as string[];
+    return succeed(filenames);
   } catch (e) {
     return fail(e);
   }

--- a/src/app/locations/_lib/utils.ts
+++ b/src/app/locations/_lib/utils.ts
@@ -87,7 +87,7 @@ export const getImageUrl = (id: string, src: string) => {
     return src;
   }
   const url = new URL(
-    `/locations/${id}/${src}.webp`,
+    `/locations/${id}/${src}`,
     process.env.NEXT_PUBLIC_PHOTO_URL,
   );
   return url.href;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,6 +2776,13 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browser-image-compression@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.2.tgz#4d5ef8882e9e471d6d923715ceb9034499d14eaa"
+  integrity sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==
+  dependencies:
+    uzip "0.20201231.0"
+
 browserslist@^4.21.9, browserslist@^4.22.1:
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.1.tgz#ba91958d1a59b87dab6fed8dfbcb3da5e2e9c619"
@@ -7701,6 +7708,11 @@ uvu@^0.5.0:
     diff "^5.0.0"
     kleur "^4.0.3"
     sade "^1.7.3"
+
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Safari では canvas や OffscreenCanvas から webp を書き出せないため、jpeg 等のファイルを許容する。
ファイルの圧縮には [browser-image-compression](https://www.npmjs.com/package/browser-image-compression) を使用する。