### PR TITLE
output: "export" を削除

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,6 @@ const withLinaria = require("next-with-linaria");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: "export",
 
   webpack: (config) => {
     config.resolve.alias["@"] = path.join(__dirname, "src");


### PR DESCRIPTION
誤って付与してしまったため、削除